### PR TITLE
Add subscribe

### DIFF
--- a/lib/replicache.dart
+++ b/lib/replicache.dart
@@ -65,7 +65,9 @@ class ScanId {
 class Replicache implements ReadTransaction {
   static MethodChannel _platform;
 
+  @Deprecated('Use subscribe instead')
   ChangeHandler onChange;
+
   SyncHandler onSync;
   SyncProgressHandler onSyncProgress;
   AuthTokenGetter getClientViewAuth;
@@ -84,6 +86,8 @@ class Replicache implements ReadTransaction {
   bool _closed = false;
   bool _reauthenticating = false;
   SyncProgress _syncProgress = SyncProgress._new(0, 0);
+  final StreamController<Null> _changeStreamController =
+      StreamController.broadcast();
 
   /// Lists information about available local databases.
   static Future<List<DatabaseInfo>> list() async {
@@ -285,6 +289,7 @@ class Replicache implements ReadTransaction {
 
   Future<void> close() async {
     _closed = true;
+    _changeStreamController.close();
     await _opened;
     await _invoke(_name, 'close');
   }
@@ -341,6 +346,23 @@ class Replicache implements ReadTransaction {
   void _fireOnChange() {
     if (onChange != null) {
       scheduleMicrotask(onChange);
+    }
+
+    // TODO(arv): We should pass the ref of the current commit to ensure we get
+    // consistent results in all the subscribe callbacks.
+    _changeStreamController.add(null);
+  }
+
+  /// Subcribe to changes to the underlying data. This returns a stream that can
+  /// be listened to. Every time the underlying data changes the listener is
+  /// invoked. The listener is also invoked once the first time the subscription
+  /// is added. There is no
+  Stream<R> subscribe<R>(Future<R> callback(ReadTransaction tx)) async* {
+    // One initial call.
+    yield await query(callback);
+
+    await for (final _ in _changeStreamController.stream) {
+      yield await query(callback);
     }
   }
 

--- a/lib/replicache.dart
+++ b/lib/replicache.dart
@@ -65,9 +65,6 @@ class ScanId {
 class Replicache implements ReadTransaction {
   static MethodChannel _platform;
 
-  @Deprecated('Use subscribe instead')
-  ChangeHandler onChange;
-
   SyncHandler onSync;
   SyncProgressHandler onSyncProgress;
   AuthTokenGetter getClientViewAuth;
@@ -344,10 +341,6 @@ class Replicache implements ReadTransaction {
   }
 
   void _fireOnChange() {
-    if (onChange != null) {
-      scheduleMicrotask(onChange);
-    }
-
     // TODO(arv): We should pass the ref of the current commit to ensure we get
     // consistent results in all the subscribe callbacks.
     _changeStreamController.add(null);
@@ -356,7 +349,9 @@ class Replicache implements ReadTransaction {
   /// Subcribe to changes to the underlying data. This returns a stream that can
   /// be listened to. Every time the underlying data changes the listener is
   /// invoked. The listener is also invoked once the first time the subscription
-  /// is added. There is no
+  /// is added. There is currently no guarantee that the result of this
+  /// subscription changes and it might get called with the same value over and
+  /// over.
   Stream<R> subscribe<R>(Future<R> callback(ReadTransaction tx)) async* {
     // One initial call.
     yield await query(callback);

--- a/sample/cal/lib/main.dart
+++ b/sample/cal/lib/main.dart
@@ -24,19 +24,17 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  List<Map<String, dynamic>> _events = [];
+  Iterable<Map<String, dynamic>> _events = [];
   Replicache _replicache = new Replicache('http://localhost:7001');
 
   _MyHomePageState() {
-    _replicache.onChange = _handleChange;
-    _replicache.onChange();
-  }
-
-  void _handleChange() async {
-    var events = List<Map<String, dynamic>>.from(
-        (await _replicache.scan(prefix: '/event/')).map((item) => item.value));
-    setState(() {
-      _events = events;
+    _replicache
+        .subscribe((tx) async =>
+            (await tx.scan(prefix: '/event/')).map((item) => item.value))
+        .listen((events) {
+      setState(() {
+        _events = events;
+      });
     });
   }
 
@@ -50,8 +48,8 @@ class _MyHomePageState extends State<MyHomePage> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: List.from(
-              _events.map((Map m) => Text(m['time'] + ': ' + m['title']))),
+          children:
+              _events.map((m) => Text(m['time'] + ': ' + m['title'])).toList(),
         ),
       ),
     );


### PR DESCRIPTION
This adds a `subscribe` method to `Replicache` class.

It currently does not take a `prefix` and it does not try to be smart
about minimizing the number of times the listener is invoked.

Closes https://github.com/rocicorp/replicache/issues/27