### PR TITLE
Do an initial sync directly after open

### DIFF
--- a/lib/replicache.dart
+++ b/lib/replicache.dart
@@ -148,7 +148,9 @@ class Replicache implements ReadTransaction {
     _opened = _staticInvoke(_name, 'open');
     _root = _getRoot();
     await _root;
-    _scheduleSync();
+    if (_syncInterval != null) {
+      await sync();
+    }
   }
 
   String get name => _name;


### PR DESCRIPTION
This regressed with 719372413c351320de3d071cd2cb54e13ed5d012