### PR TITLE
We'll do it live

### DIFF
--- a/sample/redo/lib/main.dart
+++ b/sample/redo/lib/main.dart
@@ -114,7 +114,7 @@ class _MyHomePageState extends State<MyHomePage> {
       diffServerUrl,
       name: loginResult.userId,
       dataLayerAuth: loginResult.userId,
-      diffServerAuth: 'sandbox',
+      diffServerAuth: diffServerAuth,
       batchUrl: batchUrl,
     );
     _replicache.onSync = _handleSync;

--- a/sample/redo/lib/settings.dart
+++ b/sample/redo/lib/settings.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-final diffServerUrl =
-    'http://${Platform.isAndroid ? '10.0.2.2' : 'localhost'}:7001/pull';
+final diffServerUrl = 'https://serve.replicache.dev/pull';
+const diffServerAuth = '1';
 const loginUrl = 'https://replicache-sample-todo.now.sh/serve/login';
 const batchUrl = 'https://replicache-sample-todo.now.sh/serve/replicache-batch';

--- a/test/replicache_test.dart
+++ b/test/replicache_test.dart
@@ -106,7 +106,7 @@ Future<void> main() async {
 
     if (recordPath == null && replays.isNotEmpty) {
       final i = replays.indexWhere((r) => r.matches(dbName, method, data));
-      expect(i, isNot(-1), reason: 'Cannot find recorded response for request - perhaps you need to update sync_replay.json');
+      expect(i, isNot(-1), reason: 'Cannot find recorded response for request: ($dbName, $method, ${utf8.decode(data)}) - perhaps you need to update sync_replay.json');
       final replay = replays[i];
       replays.removeAt(i);
       return replay.responseBody;
@@ -503,11 +503,11 @@ Future<void> main() async {
     await useReplay('./sync_replay.json');
 
     rep = await Replicache.forTesting(
-      'http://localhost:7001/pull',
+      'https://serve.replicache.dev/pull',
       name: 'sync',
       batchUrl: 'https://replicache-sample-todo.now.sh/serve/replicache-batch',
       dataLayerAuth: '1',
-      diffServerAuth: 'sandbox',
+      diffServerAuth: '1',
     );
 
     Completer c = Completer();

--- a/test/sync_replay.json
+++ b/test/sync_replay.json
@@ -14,8 +14,8 @@
   {
     "dbName": "sync",
     "method": "beginSync",
-    "data": "{\"batchPushURL\":\"https://replicache-sample-todo.now.sh/serve/replicache-batch\",\"diffServerURL\":\"https://diff-server.now.sh/pull\",\"dataLayerAuth\":\"1\",\"diffServerAuth\":\"1\"}",
-    "responseBody": "{\"syncHead\":\"0694b1i7sf74c402rsjva2bsvjhij93b\",\"syncInfo\":{\"clientViewInfo\":{\"httpStatusCode\":400,\"errorMessage\":\"\"}}}"
+    "data": "{\"batchPushURL\":\"https://replicache-sample-todo.now.sh/serve/replicache-batch\",\"diffServerURL\":\"https://serve.replicache.dev/pull\",\"dataLayerAuth\":\"1\",\"diffServerAuth\":\"1\"}",
+    "responseBody": "{\"syncHead\":\"ut2e5l3sionstjdnieslfro6qoepa7is\",\"syncInfo\":{\"clientViewInfo\":{\"httpStatusCode\":400,\"errorMessage\":\"\"}}}"
   },
   {
     "dbName": "sync",
@@ -33,7 +33,7 @@
     "dbName": "sync",
     "method": "commitTransaction",
     "data": "{\"transactionId\":1}",
-    "responseBody": "{\"ref\":\"rqc8jqb3pilbcjn3rat0p3idr6msr92q\"}"
+    "responseBody": "{\"ref\":\"lplsjmkqjbopav44m7c0veg9hl9kh5ee\"}"
   },
   {
     "dbName": "sync",
@@ -61,15 +61,15 @@
   },
   {
     "dbName": "sync",
-    "method": "openTransaction",
-    "data": "{\"args\":{\"id\":22354345,\"listId\":1,\"text\":\"Test 2\",\"complete\":false,\"order\":20000},\"name\":\"createTodo\"}",
-    "responseBody": "{\"transactionId\":4}"
-  },
-  {
-    "dbName": "sync",
     "method": "closeTransaction",
     "data": "{\"transactionId\":3}",
     "responseBody": "{}"
+  },
+  {
+    "dbName": "sync",
+    "method": "openTransaction",
+    "data": "{\"args\":{\"id\":22354345,\"listId\":1,\"text\":\"Test 2\",\"complete\":false,\"order\":20000},\"name\":\"createTodo\"}",
+    "responseBody": "{\"transactionId\":4}"
   },
   {
     "dbName": "sync",
@@ -81,7 +81,7 @@
     "dbName": "sync",
     "method": "commitTransaction",
     "data": "{\"transactionId\":4}",
-    "responseBody": "{\"ref\":\"6v0as7i9b3g2fi5nnousspj099lst75s\"}"
+    "responseBody": "{\"ref\":\"j6gltbuf2kv5l30q8g0hrg67qhokk6g8\"}"
   },
   {
     "dbName": "sync",
@@ -109,15 +109,9 @@
   },
   {
     "dbName": "sync",
-    "method": "closeTransaction",
-    "data": "{\"transactionId\":6}",
-    "responseBody": "{}"
-  },
-  {
-    "dbName": "sync",
     "method": "maybeEndSync",
-    "data": "{\"syncHead\":\"0694b1i7sf74c402rsjva2bsvjhij93b\"}",
-    "responseBody": "{\"replayMutations\":[{\"id\":1,\"name\":\"createTodo\",\"args\":{\"complete\":false,\"id\":14323534,\"listId\":1,\"order\":10000,\"text\":\"Test\"},\"original\":\"rqc8jqb3pilbcjn3rat0p3idr6msr92q\"},{\"id\":2,\"name\":\"createTodo\",\"args\":{\"complete\":false,\"id\":22354345,\"listId\":1,\"order\":20000,\"text\":\"Test 2\"},\"original\":\"6v0as7i9b3g2fi5nnousspj099lst75s\"}]}"
+    "data": "{\"syncHead\":\"ut2e5l3sionstjdnieslfro6qoepa7is\"}",
+    "responseBody": "{\"replayMutations\":[{\"id\":1,\"name\":\"createTodo\",\"args\":{\"complete\":false,\"id\":14323534,\"listId\":1,\"order\":10000,\"text\":\"Test\"},\"original\":\"lplsjmkqjbopav44m7c0veg9hl9kh5ee\"},{\"id\":2,\"name\":\"createTodo\",\"args\":{\"complete\":false,\"id\":22354345,\"listId\":1,\"order\":20000,\"text\":\"Test 2\"},\"original\":\"j6gltbuf2kv5l30q8g0hrg67qhokk6g8\"}]}"
   },
   {
     "dbName": "sync",
@@ -127,8 +121,14 @@
   },
   {
     "dbName": "sync",
+    "method": "closeTransaction",
+    "data": "{\"transactionId\":6}",
+    "responseBody": "{}"
+  },
+  {
+    "dbName": "sync",
     "method": "openTransaction",
-    "data": "{\"args\":{\"complete\":false,\"id\":14323534,\"listId\":1,\"order\":10000,\"text\":\"Test\"},\"name\":\"createTodo\",\"rebaseOpts\":{\"basis\":\"0694b1i7sf74c402rsjva2bsvjhij93b\",\"original\":\"rqc8jqb3pilbcjn3rat0p3idr6msr92q\"}}",
+    "data": "{\"args\":{\"complete\":false,\"id\":14323534,\"listId\":1,\"order\":10000,\"text\":\"Test\"},\"name\":\"createTodo\",\"rebaseOpts\":{\"basis\":\"ut2e5l3sionstjdnieslfro6qoepa7is\",\"original\":\"lplsjmkqjbopav44m7c0veg9hl9kh5ee\"}}",
     "responseBody": "{\"transactionId\":8}"
   },
   {
@@ -147,13 +147,13 @@
     "dbName": "sync",
     "method": "commitTransaction",
     "data": "{\"transactionId\":7}",
-    "responseBody": "{\"ref\":\"6otpcoainrvdnip27sv78i2hb9vvcmg1\"}"
+    "responseBody": "{\"ref\":\"f34jqctk544amn5etie6upec3a9i6jl1\"}"
   },
   {
     "dbName": "sync",
     "method": "commitTransaction",
     "data": "{\"transactionId\":8}",
-    "responseBody": "{\"ref\":\"2pst6tuh1kmh4fbhl5afbjhamb94lmer\"}"
+    "responseBody": "{\"ref\":\"5hde6ct4584udsgn4cta50n1smtad350\"}"
   },
   {
     "dbName": "sync",
@@ -164,7 +164,7 @@
   {
     "dbName": "sync",
     "method": "openTransaction",
-    "data": "{\"args\":{\"complete\":false,\"id\":22354345,\"listId\":1,\"order\":20000,\"text\":\"Test 2\"},\"name\":\"createTodo\",\"rebaseOpts\":{\"basis\":\"2pst6tuh1kmh4fbhl5afbjhamb94lmer\",\"original\":\"6v0as7i9b3g2fi5nnousspj099lst75s\"}}",
+    "data": "{\"args\":{\"complete\":false,\"id\":22354345,\"listId\":1,\"order\":20000,\"text\":\"Test 2\"},\"name\":\"createTodo\",\"rebaseOpts\":{\"basis\":\"5hde6ct4584udsgn4cta50n1smtad350\",\"original\":\"j6gltbuf2kv5l30q8g0hrg67qhokk6g8\"}}",
     "responseBody": "{\"transactionId\":10}"
   },
   {
@@ -195,7 +195,7 @@
     "dbName": "sync",
     "method": "commitTransaction",
     "data": "{\"transactionId\":10}",
-    "responseBody": "{\"ref\":\"g2veiugjdhnhofv241vovu3271u33pg9\"}"
+    "responseBody": "{\"ref\":\"bu9pdqismbddcor1otn5m8fubac5pmir\"}"
   },
   {
     "dbName": "sync",
@@ -206,13 +206,13 @@
   {
     "dbName": "sync",
     "method": "maybeEndSync",
-    "data": "{\"syncHead\":\"g2veiugjdhnhofv241vovu3271u33pg9\"}",
-    "responseBody": "{\"replayMutations\":[{\"id\":3,\"name\":\"createTodo\",\"args\":{\"complete\":false,\"id\":34645673,\"listId\":1,\"order\":30000,\"text\":\"Test 3\"},\"original\":\"6otpcoainrvdnip27sv78i2hb9vvcmg1\"}]}"
+    "data": "{\"syncHead\":\"bu9pdqismbddcor1otn5m8fubac5pmir\"}",
+    "responseBody": "{\"replayMutations\":[{\"id\":3,\"name\":\"createTodo\",\"args\":{\"complete\":false,\"id\":34645673,\"listId\":1,\"order\":30000,\"text\":\"Test 3\"},\"original\":\"f34jqctk544amn5etie6upec3a9i6jl1\"}]}"
   },
   {
     "dbName": "sync",
     "method": "openTransaction",
-    "data": "{\"args\":{\"complete\":false,\"id\":34645673,\"listId\":1,\"order\":30000,\"text\":\"Test 3\"},\"name\":\"createTodo\",\"rebaseOpts\":{\"basis\":\"g2veiugjdhnhofv241vovu3271u33pg9\",\"original\":\"6otpcoainrvdnip27sv78i2hb9vvcmg1\"}}",
+    "data": "{\"args\":{\"complete\":false,\"id\":34645673,\"listId\":1,\"order\":30000,\"text\":\"Test 3\"},\"name\":\"createTodo\",\"rebaseOpts\":{\"basis\":\"bu9pdqismbddcor1otn5m8fubac5pmir\",\"original\":\"f34jqctk544amn5etie6upec3a9i6jl1\"}}",
     "responseBody": "{\"transactionId\":12}"
   },
   {
@@ -225,12 +225,12 @@
     "dbName": "sync",
     "method": "commitTransaction",
     "data": "{\"transactionId\":12}",
-    "responseBody": "{\"ref\":\"imo4qsiept07mhdk5is9ihhec2ebdbsn\"}"
+    "responseBody": "{\"ref\":\"aaq42qane1jdiqconh0s6sdssaln40op\"}"
   },
   {
     "dbName": "sync",
     "method": "maybeEndSync",
-    "data": "{\"syncHead\":\"imo4qsiept07mhdk5is9ihhec2ebdbsn\"}",
+    "data": "{\"syncHead\":\"aaq42qane1jdiqconh0s6sdssaln40op\"}",
     "responseBody": "{}"
   },
   {
@@ -248,7 +248,7 @@
   {
     "dbName": "sync",
     "method": "beginSync",
-    "data": "{\"batchPushURL\":\"https://replicache-sample-todo.now.sh/serve/replicache-batch\",\"diffServerURL\":\"https://diff-server.now.sh/pull\",\"dataLayerAuth\":\"1\",\"diffServerAuth\":\"1\"}",
+    "data": "{\"batchPushURL\":\"https://replicache-sample-todo.now.sh/serve/replicache-batch\",\"diffServerURL\":\"https://serve.replicache.dev/pull\",\"dataLayerAuth\":\"1\",\"diffServerAuth\":\"1\"}",
     "responseBody": "{\"syncHead\":\"00000000000000000000000000000000\",\"syncInfo\":{\"batchPushInfo\":{\"httpStatusCode\":200,\"errorMessage\":\"\",\"batchPushResponse\":{}},\"clientViewInfo\":{\"httpStatusCode\":400,\"errorMessage\":\"\"}}}"
   },
   {
@@ -267,7 +267,7 @@
     "dbName": "sync",
     "method": "commitTransaction",
     "data": "{\"transactionId\":14}",
-    "responseBody": "{\"ref\":\"gvt9p4v34nbdfngeoqnp10crhslhmuum\"}"
+    "responseBody": "{\"ref\":\"1vdpgggh1t57ire1ja0dq60qoms28t8k\"}"
   },
   {
     "dbName": "sync",
@@ -297,7 +297,7 @@
     "dbName": "sync",
     "method": "commitTransaction",
     "data": "{\"transactionId\":16}",
-    "responseBody": "{\"ref\":\"34ap4mkpvus2q5o1d7o4sqs3q95gs7kb\"}"
+    "responseBody": "{\"ref\":\"95dd269rpun19vd0q6rb2frug2rv84st\"}"
   },
   {
     "dbName": "sync",
@@ -327,7 +327,7 @@
     "dbName": "sync",
     "method": "commitTransaction",
     "data": "{\"transactionId\":18}",
-    "responseBody": "{\"ref\":\"t0k07f7gupdtmnui0l9920afisf3ac4v\"}"
+    "responseBody": "{\"ref\":\"8u6t8mpasb6ol63mrjttcffv1nek24v0\"}"
   },
   {
     "dbName": "sync",
@@ -344,7 +344,7 @@
   {
     "dbName": "sync",
     "method": "beginSync",
-    "data": "{\"batchPushURL\":\"https://replicache-sample-todo.now.sh/serve/replicache-batch\",\"diffServerURL\":\"https://diff-server.now.sh/pull\",\"dataLayerAuth\":\"1\",\"diffServerAuth\":\"1\"}",
+    "data": "{\"batchPushURL\":\"https://replicache-sample-todo.now.sh/serve/replicache-batch\",\"diffServerURL\":\"https://serve.replicache.dev/pull\",\"dataLayerAuth\":\"1\",\"diffServerAuth\":\"1\"}",
     "responseBody": "{\"syncHead\":\"00000000000000000000000000000000\",\"syncInfo\":{\"batchPushInfo\":{\"httpStatusCode\":200,\"errorMessage\":\"\",\"batchPushResponse\":{\"mutationInfos\":[{\"id\":1,\"error\":\"mutation has already been processed\"},{\"id\":2,\"error\":\"mutation has already been processed\"},{\"id\":3,\"error\":\"mutation has already been processed\"}]}},\"clientViewInfo\":{\"httpStatusCode\":400,\"errorMessage\":\"\"}}}"
   },
   {


### PR DESCRIPTION
Finally! With the diff-server auth plumbed through, we can just use the public diff-server for redo and tests, rather than having to run another server locally. I think this is a better development experience, one less thingy that needs to be running. And a better experience for people trying out sample apps.

Also, for the sample app, I need this in order to demo offline. It's more difficult to simulate local hosts being unavailable than the public internet.

This does make more obvious that diff-server must maintain a backward-compatible HTTP interface to repm. However, that was always the case - there was no version pinning between repm and diff-server. Also we will need this to be the case once we are being used.

If it turns out to be useful for some reason to use the local diff-server we could add additional flags to test_server and/or redo.