### PR TITLE
Prevent nested transactions

### DIFF
--- a/lib/replicache.dart
+++ b/lib/replicache.dart
@@ -1,5 +1,11 @@
 export 'src/replicache.dart'
-    show Replicache, SyncHandler, AuthTokenGetter, Mutator, MutatorImpl;
+    show
+        Replicache,
+        SyncHandler,
+        AuthTokenGetter,
+        Mutator,
+        MutatorImpl,
+        NestedTransactionError;
 export 'src/log.dart' show LogLevel;
 export 'src/scan_item.dart';
 export 'src/scan_id.dart';

--- a/test/fixtures/nested tx mutate.json
+++ b/test/fixtures/nested tx mutate.json
@@ -1,0 +1,81 @@
+[
+  {
+    "dbName": "nested-tx-mutate",
+    "method": "open",
+    "args": {},
+    "result": ""
+  },
+  {
+    "dbName": "nested-tx-mutate",
+    "method": "getRoot",
+    "args": {},
+    "result": {
+      "root": "e99uif9c7bpavajrt666es1ki52dv239"
+    }
+  },
+  {
+    "dbName": "nested-tx-mutate",
+    "method": "openTransaction",
+    "args": {
+      "args": 42,
+      "name": "mut"
+    },
+    "result": {
+      "transactionId": 1
+    }
+  },
+  {
+    "dbName": "nested-tx-mutate",
+    "method": "commitTransaction",
+    "args": {
+      "transactionId": 1
+    },
+    "result": {
+      "ref": "e99uif9c7bpavajrt666es1ki52dv239"
+    }
+  },
+  {
+    "dbName": "nested-tx-mutate",
+    "method": "openTransaction",
+    "args": {
+      "args": 1,
+      "name": "mut2"
+    },
+    "result": {
+      "transactionId": 2
+    }
+  },
+  {
+    "dbName": "nested-tx-mutate",
+    "method": "openTransaction",
+    "args": {
+      "args": null,
+      "name": "mut3"
+    },
+    "result": {
+      "transactionId": 3
+    }
+  },
+  {
+    "dbName": "nested-tx-mutate",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 2
+    },
+    "result": {}
+  },
+  {
+    "dbName": "nested-tx-mutate",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 3
+    },
+    "result": {}
+  },
+  {
+    "dbName": "nested-tx-mutate",
+    "method": "close",
+    "args": {},
+    "result": ""
+  }
+]

--- a/test/fixtures/nested tx subscribe.json
+++ b/test/fixtures/nested tx subscribe.json
@@ -1,0 +1,38 @@
+[
+  {
+    "dbName": "nested-tx-subscribe",
+    "method": "open",
+    "args": {},
+    "result": ""
+  },
+  {
+    "dbName": "nested-tx-subscribe",
+    "method": "getRoot",
+    "args": {},
+    "result": {
+      "root": "e99uif9c7bpavajrt666es1ki52dv239"
+    }
+  },
+  {
+    "dbName": "nested-tx-subscribe",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 1
+    }
+  },
+  {
+    "dbName": "nested-tx-subscribe",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 1
+    },
+    "result": {}
+  },
+  {
+    "dbName": "nested-tx-subscribe",
+    "method": "close",
+    "args": {},
+    "result": ""
+  }
+]

--- a/test/fixtures/nested tx.json
+++ b/test/fixtures/nested tx.json
@@ -1,0 +1,70 @@
+[
+  {
+    "dbName": "nested-tx",
+    "method": "open",
+    "args": {},
+    "result": ""
+  },
+  {
+    "dbName": "nested-tx",
+    "method": "getRoot",
+    "args": {},
+    "result": {
+      "root": "e99uif9c7bpavajrt666es1ki52dv239"
+    }
+  },
+  {
+    "dbName": "nested-tx",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 1
+    }
+  },
+  {
+    "dbName": "nested-tx",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 1
+    },
+    "result": {}
+  },
+  {
+    "dbName": "nested-tx",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 2
+    }
+  },
+  {
+    "dbName": "nested-tx",
+    "method": "openTransaction",
+    "args": {},
+    "result": {
+      "transactionId": 3
+    }
+  },
+  {
+    "dbName": "nested-tx",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 2
+    },
+    "result": {}
+  },
+  {
+    "dbName": "nested-tx",
+    "method": "closeTransaction",
+    "args": {
+      "transactionId": 3
+    },
+    "result": {}
+  },
+  {
+    "dbName": "nested-tx",
+    "method": "close",
+    "args": {},
+    "result": ""
+  }
+]


### PR DESCRIPTION
We use Dart Zones to ensue that we have no nested transactions. We throw
a custom Error class in case of nested tx.

Fixes https://github.com/rocicorp/replicache/issues/49